### PR TITLE
Bugfix: Do not use lizmapProject in ows request

### DIFF
--- a/wps/classes/wpsOGCRequest.class.php
+++ b/wps/classes/wpsOGCRequest.class.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Manage OGC request.
+ *
+ * @author    3liz
+ * @copyright 2015 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+class wpsOGCRequest extends lizmapOGCRequest {
+{
+    protected $params;
+
+    protected $xml_post = null;
+
+    protected $services;
+
+    protected $tplExceptions;
+
+    protected $ows_url;
+
+    /**
+     * constructor
+     * params : the params array
+     * xml_post : the post request as SimpleXML element
+     */
+    public function __construct ( $params, $xml_post=null ) {
+        $this->services = lizmap::getServices();
+        $nParams = lizmapProxy::normalizeParams($params);
+        foreach ( $params as $k=>$v ) {
+            if ( strtolower($k) === 'repository' || strtolower($k) === 'project' ){
+                $nParams[strtolower($k)] = $v;
+            }
+        }
+        $this->params = $nParams;
+        $this->xml_post = $xml_post;
+
+        $localConfig = jApp::configPath('localconfig.ini.php');
+        $localConfig = new jIniFileModifier($localConfig);
+        $this->ows_url = $localConfig->getValue('ows_url', 'wps');
+    }
+
+    public function process ( ) {
+        $req = $this->param('request');
+        if ($req && method_exists($this, $req)) {
+            return $this->{$req}();
+        }
+
+        if (!$req) {
+            jMessage::add('Please add or check the value of the REQUEST parameter', 'OperationNotSupported');
+        } else {
+            jMessage::add('Request '.$req.' is not supported', 'OperationNotSupported');
+        }
+
+        return $this->serviceException(501);
+    }
+
+    protected function constructUrl ( ) {
+        $url = $this->ows_url;
+        if (strpos($url, '?') === false)
+            $url .= '?';
+
+        $params = Array();
+        foreach ( $this->params as $k=>$v ) {
+            if ( $k !== '__httpbody' )
+                $params[$k] = $v;
+        }
+
+        $bparams = http_build_query($params);
+
+        // replace some chars (not needed in php 5.4, use the 4th parameter of http_build_query)
+        $a = array('+', '_', '.', '-');
+        $b = array('%20', '%5F', '%2E', '%2D');
+        $bparams = str_replace($a, $b, $bparams);
+
+        $querystring = $url . $bparams;
+        return $querystring;
+    }
+
+    protected function getcapabilities()
+    {
+        $querystring = $this->constructUrl();
+
+        // Get remote data
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
+
+        // Retry if 500 error ( hackish, but QGIS Server segfault sometimes with cache issue )
+        if ($code == 500) {
+            // Get remote data
+            list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
+        }
+
+        return (object) array(
+            'code' => $code,
+            'mime' => $mime,
+            'data' => $data,
+            'cached' => false,
+        );
+    }
+
+    /**
+     * get
+     * @return request.
+     */
+    protected function get(){
+        $querystring = $this->constructUrl();
+
+        // Get remote data
+        $getRemoteData = lizmapProxy::getRemoteData(
+          $querystring,
+          $this->services->proxyMethod,
+          $this->services->debugMode
+        );
+        $data = $getRemoteData[0];
+        $mime = $getRemoteData[1];
+        $code = $getRemoteData[2];
+
+        return (object) array(
+            'code' => $code,
+            'mime' => $mime,
+            'data' => $data,
+            'cached' => False
+        );
+    }
+
+    /**
+     * post
+     * @param string $xml_post
+     * @return request.
+     */
+    protected function post(){
+        $querystring = $this->constructUrl();
+
+        // Get data form server
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_URL, $querystring);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->xml_post);
+        $data = curl_exec($ch);
+        $info = curl_getinfo($ch);
+        $mime = $info['content_type'];
+        $code = (int) $info['http_code'];
+        curl_close($ch);
+
+
+        return (object) array(
+            'code' => $code,
+            'mime' => $mime,
+            'data' => $data,
+            'cached' => False
+        );
+    }
+
+}

--- a/wps/classes/wpsWCSRequest.class.php
+++ b/wps/classes/wpsWCSRequest.class.php
@@ -9,61 +9,15 @@
 * @license Mozilla Public License : http://www.mozilla.org/MPL/
 */
 
-class wpsWCSRequest extends lizmapOGCRequest {
+class wpsWCSRequest extends wpsOGCRequest {
 
     protected $tplExceptions = 'wps~wcs_exception';
-    protected $xml_post = null;
-
-    /**
-     * constructor
-     * project : the project has a lizmapProject Class
-     * params : the params array
-     */
-    public function __construct ( $params, $xml_post=null ) {
-        $this->services = lizmap::getServices();
-        $nParams = lizmapProxy::normalizeParams($params);
-        foreach ( $params as $k=>$v ) {
-            if ( strtolower($k) === 'repository' || strtolower($k) === 'project' ){
-                $nParams[strtolower($k)] = $v;
-            }
-        }
-        $this->params = $nParams;
-        $this->xml_post = $xml_post;
-
-        $localConfig = jApp::configPath('localconfig.ini.php');
-        $localConfig = new jIniFileModifier($localConfig);
-        $this->ows_url = $localConfig->getValue('ows_url', 'wps');
-    }
-
-    public function process ( ) {
-        if ( $this->xml_post !== null )
-            return $this->post();
-        return $this->{$this->param('request')}();
-    }
 
     protected function constructUrl ( ) {
-        $url = $this->ows_url;
-        if (strpos($url, '?') === false)
-            $url .= '?';
+        if ( !array_key_exists('service', $this->params) )
+            $this->params['service'] = 'WCS';
 
-        $params = Array();
-        foreach ( $this->params as $k=>$v ) {
-            if ( $k !== '__httpbody' )
-                $params[$k] = $v;
-        }
-
-        if ( !array_key_exists('service', $params) )
-            $params['service'] = 'WCS';
-
-        $bparams = http_build_query($params);
-
-        // replace some chars (not needed in php 5.4, use the 4th parameter of http_build_query)
-        $a = array('+', '_', '.', '-');
-        $b = array('%20', '%5F', '%2E', '%2D');
-        $bparams = str_replace($a, $b, $bparams);
-
-        $querystring = $url . $bparams;
-        return $querystring;
+        return parent::constructUrl();
     }
 
     protected function getcapabilities ( ) {
@@ -140,64 +94,6 @@ class wpsWCSRequest extends lizmapOGCRequest {
         }
 
         return $result;
-    }
-
-    /**
-     * get
-     * @return request.
-     */
-    protected function get(){
-        $querystring = $this->constructUrl();
-
-        // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
-    }
-
-    /**
-     * post
-     * @param string $xml_post
-     * @return request.
-     */
-    protected function post(){
-        $querystring = $this->constructUrl();
-
-        // Get data form server
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_URL, $querystring);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->xml_post);
-        $data = curl_exec($ch);
-        $info = curl_getinfo($ch);
-        $mime = $info['content_type'];
-        $code = (int) $info['http_code'];
-        curl_close($ch);
-
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
     }
 
 }

--- a/wps/classes/wpsWFSRequest.class.php
+++ b/wps/classes/wpsWFSRequest.class.php
@@ -9,61 +9,15 @@
 * @license Mozilla Public License : http://www.mozilla.org/MPL/
 */
 
-class wpsWFSRequest extends lizmapOGCRequest {
+class wpsWFSRequest extends wpsOGCRequest {
 
     protected $tplExceptions = 'lizmap~wfs_exception';
-    protected $xml_post = null;
-
-    /**
-     * constructor
-     * project : the project has a lizmapProject Class
-     * params : the params array
-     */
-    public function __construct ( $params, $xml_post=null ) {
-        $this->services = lizmap::getServices();
-        $nParams = lizmapProxy::normalizeParams($params);
-        foreach ( $params as $k=>$v ) {
-            if ( strtolower($k) === 'repository' || strtolower($k) === 'project' ){
-                $nParams[strtolower($k)] = $v;
-            }
-        }
-        $this->params = $nParams;
-        $this->xml_post = $xml_post;
-
-        $localConfig = jApp::configPath('localconfig.ini.php');
-        $localConfig = new jIniFileModifier($localConfig);
-        $this->ows_url = $localConfig->getValue('ows_url', 'wps');
-    }
-
-    public function process ( ) {
-        if ( $this->xml_post !== null )
-            return $this->post();
-        return $this->{$this->param('request')}();
-    }
 
     protected function constructUrl ( ) {
-        $url = $this->ows_url;
-        if (strpos($url, '?') === false)
-            $url .= '?';
+        if ( !array_key_exists('service', $this->params) )
+            $this->params['service'] = 'WFS';
 
-        $params = Array();
-        foreach ( $this->params as $k=>$v ) {
-            if ( $k !== '__httpbody' )
-                $params[$k] = $v;
-        }
-
-        if ( !array_key_exists('service', $params) )
-            $params['service'] = 'WFS';
-
-        $bparams = http_build_query($params);
-
-        // replace some chars (not needed in php 5.4, use the 4th parameter of http_build_query)
-        $a = array('+', '_', '.', '-');
-        $b = array('%20', '%5F', '%2E', '%2D');
-        $bparams = str_replace($a, $b, $bparams);
-
-        $querystring = $url . $bparams;
-        return $querystring;
+        return parent::constructUrl();
     }
 
     protected function getcapabilities ( ) {
@@ -161,64 +115,6 @@ class wpsWFSRequest extends lizmapOGCRequest {
         }
 
         return $result;
-    }
-
-    /**
-     * get
-     * @return request.
-     */
-    protected function get(){
-        $querystring = $this->constructUrl();
-
-        // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
-    }
-
-    /**
-     * post
-     * @param string $xml_post
-     * @return request.
-     */
-    protected function post(){
-        $querystring = $this->constructUrl();
-
-        // Get data form server
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_URL, $querystring);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->xml_post);
-        $data = curl_exec($ch);
-        $info = curl_getinfo($ch);
-        $mime = $info['content_type'];
-        $code = (int) $info['http_code'];
-        curl_close($ch);
-
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
     }
 
 }

--- a/wps/classes/wpsWMSRequest.class.php
+++ b/wps/classes/wpsWMSRequest.class.php
@@ -9,61 +9,15 @@
 * @license Mozilla Public License : http://www.mozilla.org/MPL/
 */
 
-class wpsWMSRequest extends lizmapOGCRequest {
+class wpsWMSRequest extends wpsOGCRequest {
 
     protected $tplExceptions = 'lizmap~wms_exception';
-    protected $xml_post = null;
-
-    /**
-     * constructor
-     * project : the project has a lizmapProject Class
-     * params : the params array
-     */
-    public function __construct ( $params, $xml_post=null ) {
-        $this->services = lizmap::getServices();
-        $nParams = lizmapProxy::normalizeParams($params);
-        foreach ( $params as $k=>$v ) {
-            if ( strtolower($k) === 'repository' || strtolower($k) === 'project' ){
-                $nParams[strtolower($k)] = $v;
-            }
-        }
-        $this->params = $nParams;
-        $this->xml_post = $xml_post;
-
-        $localConfig = jApp::configPath('localconfig.ini.php');
-        $localConfig = new jIniFileModifier($localConfig);
-        $this->ows_url = $localConfig->getValue('ows_url', 'wps');
-    }
-
-    public function process ( ) {
-        if ( $this->xml_post !== null )
-            return $this->post();
-        return $this->{$this->param('request')}();
-    }
 
     protected function constructUrl ( ) {
-        $url = $this->ows_url;
-        if (strpos($url, '?') === false)
-            $url .= '?';
+        if ( !array_key_exists('service', $this->params) )
+            $this->params['service'] = 'WMS';
 
-        $params = Array();
-        foreach ( $this->params as $k=>$v ) {
-            if ( $k !== '__httpbody' )
-                $params[$k] = $v;
-        }
-
-        if ( !array_key_exists('service', $params) )
-            $params['service'] = 'WMS';
-
-        $bparams = http_build_query($params);
-
-        // replace some chars (not needed in php 5.4, use the 4th parameter of http_build_query)
-        $a = array('+', '_', '.', '-');
-        $b = array('%20', '%5F', '%2E', '%2D');
-        $bparams = str_replace($a, $b, $bparams);
-
-        $querystring = $url . $bparams;
-        return $querystring;
+        return parent::constructUrl();
     }
 
     protected function getcapabilities ( ) {
@@ -184,64 +138,6 @@ class wpsWMSRequest extends lizmapOGCRequest {
         }
 
         return $result;
-    }
-
-    /**
-     * get
-     * @return request.
-     */
-    protected function get(){
-        $querystring = $this->constructUrl();
-
-        // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
-    }
-
-    /**
-     * post
-     * @param string $xml_post
-     * @return request.
-     */
-    protected function post(){
-        $querystring = $this->constructUrl();
-
-        // Get data form server
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_URL, $querystring);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->xml_post);
-        $data = curl_exec($ch);
-        $info = curl_getinfo($ch);
-        $mime = $info['content_type'];
-        $code = (int) $info['http_code'];
-        curl_close($ch);
-
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
     }
 
 }

--- a/wps/module.xml
+++ b/wps/module.xml
@@ -16,6 +16,7 @@
     </dependencies>
     <autoload>
         <class name="lizmapWPSRequest" file="classes/lizmapWPSRequest.class.php" />
+        <class name="wpsOGCRequest" file="classes/wpsOGCRequest.class.php" />
         <class name="wpsWMSRequest" file="classes/wpsWMSRequest.class.php" />
         <class name="wpsWFSRequest" file="classes/wpsWFSRequest.class.php" />
         <class name="wpsWCSRequest" file="classes/wpsWCSRequest.class.php" />


### PR DESCRIPTION
## Description

Add a specfic `wpsOGCRequest` to fix an issue with `lizmapOGCRequest`. `lizmapOGCRequest` needs a `lizmapProject`. In the controllers `ows`, the request is done on QGIS project without lizmap config. So in ows controller there is no `lizmapProject` available.