### PR TITLE
Refactor HTTP calls

### DIFF
--- a/wps/classes/processStatus.class.php
+++ b/wps/classes/processStatus.class.php
@@ -32,14 +32,8 @@ class processStatus {
 
     public function saved ( $identifier, $repository, $project ) {
         $url = $this->url.'?SERVICE=WPS';
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $url//,
-          //$this->services->proxyMethod,
-          //$this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
+
         if ( empty( $data ) or floor( $code / 100 ) >= 4 )
             $data = array();
 
@@ -73,14 +67,7 @@ class processStatus {
 
     public function get( $identifier, $repository, $project, $uuid ) {
         $url = $this->url.$uuid.'?SERVICE=WPS';
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $url//,
-          //$this->services->proxyMethod,
-          //$this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
 
         $saved = $this->saved( $identifier, $repository, $project );
 

--- a/wps/classes/wpsOGCRequest.class.php
+++ b/wps/classes/wpsOGCRequest.class.php
@@ -99,54 +99,32 @@ class wpsOGCRequest extends lizmapOGCRequest {
     }
 
     /**
-     * get
-     * @return request.
+     * @return array
      */
-    protected function get(){
+    protected function doRequest()
+    {
         $querystring = $this->constructUrl();
 
-        // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
+        if ($this->xml_post !== null) {
+            $options = array(
+                "method" => "post",
+                "headers" => array(
+                    "Content-Type" => "text/xml"
+                ),
+                "body" =>$this->xml_post
+            );
+        }
+        else {
+            $options = array(
+                "method" => "get",
+            );
+        }
+
+        // launch request
+        list($data, $mime, $code) = lizmapProxy::getRemoteData(
+            $querystring,
+            $options
         );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
-
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => False
-        );
-    }
-
-    /**
-     * post
-     * @param string $xml_post
-     * @return request.
-     */
-    protected function post(){
-        $querystring = $this->constructUrl();
-
-        // Get data form server
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_URL, $querystring);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->xml_post);
-        $data = curl_exec($ch);
-        $info = curl_getinfo($ch);
-        $mime = $info['content_type'];
-        $code = (int) $info['http_code'];
-        curl_close($ch);
-
 
         return (object) array(
             'code' => $code,

--- a/wps/classes/wpsWCSRequest.class.php
+++ b/wps/classes/wpsWCSRequest.class.php
@@ -54,12 +54,9 @@ class wpsWCSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function describecoverage ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function describecoverage()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -75,12 +72,9 @@ class wpsWCSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getcoverage ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getcoverage()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');

--- a/wps/classes/wpsWFSRequest.class.php
+++ b/wps/classes/wpsWFSRequest.class.php
@@ -54,12 +54,9 @@ class wpsWFSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function describefeaturetype ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function describefeaturetype()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -75,12 +72,9 @@ class wpsWFSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getfeature ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getfeature()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -96,12 +90,9 @@ class wpsWFSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function transaction ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function transaction()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');

--- a/wps/classes/wpsWMSRequest.class.php
+++ b/wps/classes/wpsWMSRequest.class.php
@@ -52,12 +52,9 @@ class wpsWMSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function getmap ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getmap()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -77,12 +74,9 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $this->getlegendgraphics();
     }
 
-    protected function getlegendgraphics ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getlegendgraphics()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -98,12 +92,9 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getfeatureinfo ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getfeatureinfo ()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');
@@ -119,12 +110,9 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getstyles ( ) {
-        $result = null;
-        if ( $this->xml_post !== null )
-            $result = $this->post();
-        else
-            $result = $this->get();
+    protected function getstyles ()
+    {
+        $result = $this->doRequest();
 
         if ( !$result ) {
             jMessage::add('Server Error !', 'Error');

--- a/wps/controllers/service.classic.php
+++ b/wps/controllers/service.classic.php
@@ -150,14 +150,7 @@ class serviceCtrl extends jController {
 
         $url = $wps_url .'store/'. $uuid .'/'. $file .'?service=WPS';
 
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $url//,
-          //$this->services->proxyMethod,
-          //$this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
 
         $rep->outputFileName = $file;
         $rep->mimeType = $mime;
@@ -186,14 +179,7 @@ class serviceCtrl extends jController {
 
         $url.= '?SERVICE=WPS';
 
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $url//,
-          //$this->services->proxyMethod,
-          //$this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
 
         if ( empty( $data ) or floor( $code / 100 ) >= 4 ) {
             $rep->setHttpStatus($code, 'Not Found');


### PR DESCRIPTION
We must always use lizmapProxy::getRemoteData instead of curl, as this method take care of some lizmap configuration parameters like proxy and so on, contrary to the current code.

We should not use deprecated parameters of getRemoteData.

To simplify the code, get and post methods have been replaced by a single method doRequest.

