### PR TITLE
Fix potential issues when calling WPS requests with unexpected method

### DIFF
--- a/wps/classes/lizmapWPSRequest.class.php
+++ b/wps/classes/lizmapWPSRequest.class.php
@@ -42,8 +42,40 @@ class lizmapWPSRequest extends lizmapOGCRequest {
         }
     }
 
-    public function process ( ) {
-        return $this->{$this->param('request')}();
+    /**
+     * Do the process
+     *
+     * @internal we override the process() method of lizmapOGCRequest to be sure
+     * we have the secure version of the method, in case where the lizmap version
+     * is <= 3.4.3, <= 3.3.15
+     *
+     * deprecated: remove this overrided method when we will mark the module compatible
+     * only with Lizmap 3.5.
+     *
+     *
+     * @return array
+     */
+    public function process ()
+    {
+        $req = $this->param('request');
+        if ($req) {
+            $reqMeth = 'process_'.$req;
+            if (method_exists($this, $reqMeth)) {
+                return $this->{$reqMeth}();
+            }
+            // old unsecure way, to be compatible with methods of lizmap <= 3.4.3, <= 3.3.15
+            else if (method_exists($this, $req)) {
+                return $this->{$req}();
+            }
+        }
+
+        if (!$req) {
+            jMessage::add('Please add or check the value of the REQUEST parameter', 'OperationNotSupported');
+        } else {
+            jMessage::add('Request '.$req.' is not supported', 'OperationNotSupported');
+        }
+
+        return $this->serviceException(501);
     }
 
     protected function constructUrl ( ) {
@@ -89,7 +121,7 @@ class lizmapWPSRequest extends lizmapOGCRequest {
         return $querystring;
     }
 
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $result = $this->doRequest();
 
@@ -127,7 +159,7 @@ class lizmapWPSRequest extends lizmapOGCRequest {
         );
     }
 
-    protected function describeprocess()
+    protected function process_describeprocess()
     {
         $result = $this->doRequest();
 
@@ -145,7 +177,7 @@ class lizmapWPSRequest extends lizmapOGCRequest {
         return $result;
     }
 
-    protected function execute()
+    protected function process_execute()
     {
         $result = $this->doRequest();
 
@@ -198,7 +230,7 @@ class lizmapWPSRequest extends lizmapOGCRequest {
         );
     }
 
-    protected function getresults()
+    protected function process_getresults()
     {
         $result = $this->doRequest();
 

--- a/wps/classes/wpsOGCRequest.class.php
+++ b/wps/classes/wpsOGCRequest.class.php
@@ -40,10 +40,27 @@ class wpsOGCRequest extends lizmapOGCRequest {
         $this->ows_url = jApp::config()->wps['ows_url'];
     }
 
-    public function process ( ) {
+    /**
+     * Do the process
+     *
+     * @internal we override the process() method of lizmapOGCRequest to be sure
+     * we have the secure version of the method, in case where the lizmap version
+     * is <= 3.4.3, <= 3.3.15
+     *
+     * @deprecated remove this overrided method when we will mark the module compatible
+     * only with Lizmap 3.5.
+     *
+     *
+     * @return array
+     */
+    public function process ()
+    {
         $req = $this->param('request');
-        if ($req && method_exists($this, $req)) {
-            return $this->{$req}();
+        if ($req) {
+            $reqMeth = 'process_'.$req;
+            if (method_exists($this, $reqMeth)) {
+                return $this->{$reqMeth}();
+            }
         }
 
         if (!$req) {
@@ -77,7 +94,7 @@ class wpsOGCRequest extends lizmapOGCRequest {
         return $querystring;
     }
 
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $querystring = $this->constructUrl();
 

--- a/wps/classes/wpsWCSRequest.class.php
+++ b/wps/classes/wpsWCSRequest.class.php
@@ -20,8 +20,9 @@ class wpsWCSRequest extends wpsOGCRequest {
         return parent::constructUrl();
     }
 
-    protected function getcapabilities ( ) {
-        $result = parent::getcapabilities();
+    protected function process_getcapabilities ( )
+    {
+        $result = parent::process_getcapabilities();
 
         $data = $result->data;
         if ( empty( $data ) or floor( $result->code / 100 ) >= 4 ) {
@@ -54,7 +55,7 @@ class wpsWCSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function describecoverage()
+    protected function process_describecoverage()
     {
         $result = $this->doRequest();
 
@@ -72,7 +73,7 @@ class wpsWCSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getcoverage()
+    protected function process_getcoverage()
     {
         $result = $this->doRequest();
 

--- a/wps/classes/wpsWFSRequest.class.php
+++ b/wps/classes/wpsWFSRequest.class.php
@@ -20,8 +20,9 @@ class wpsWFSRequest extends wpsOGCRequest {
         return parent::constructUrl();
     }
 
-    protected function getcapabilities ( ) {
-        $result = parent::getcapabilities();
+    protected function process_getcapabilities()
+    {
+        $result = parent::process_getcapabilities();
 
         $data = $result->data;
         if ( empty( $data ) or floor( $result->code / 100 ) >= 4 ) {
@@ -54,7 +55,7 @@ class wpsWFSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function describefeaturetype()
+    protected function process_describefeaturetype()
     {
         $result = $this->doRequest();
 
@@ -72,7 +73,7 @@ class wpsWFSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getfeature()
+    protected function process_getfeature()
     {
         $result = $this->doRequest();
 
@@ -90,7 +91,7 @@ class wpsWFSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function transaction()
+    protected function process_transaction()
     {
         $result = $this->doRequest();
 

--- a/wps/classes/wpsWMSRequest.class.php
+++ b/wps/classes/wpsWMSRequest.class.php
@@ -20,8 +20,8 @@ class wpsWMSRequest extends wpsOGCRequest {
         return parent::constructUrl();
     }
 
-    protected function getcapabilities ( ) {
-        $result = parent::getcapabilities();
+    protected function process_getcapabilities ( ) {
+        $result = parent::process_getcapabilities();
 
         $data = $result->data;
         if ( empty( $data ) or floor( $result->code / 100 ) >= 4 ) {
@@ -52,7 +52,7 @@ class wpsWMSRequest extends wpsOGCRequest {
         );
     }
 
-    protected function getmap()
+    protected function process_getmap()
     {
         $result = $this->doRequest();
 
@@ -70,11 +70,11 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getlegendgraphic ( ) {
-        return $this->getlegendgraphics();
+    protected function process_getlegendgraphic ( ) {
+        return $this->process_getlegendgraphics();
     }
 
-    protected function getlegendgraphics()
+    protected function process_getlegendgraphics()
     {
         $result = $this->doRequest();
 
@@ -92,7 +92,7 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getfeatureinfo ()
+    protected function process_getfeatureinfo ()
     {
         $result = $this->doRequest();
 
@@ -110,7 +110,7 @@ class wpsWMSRequest extends wpsOGCRequest {
         return $result;
     }
 
-    protected function getstyles ()
+    protected function process_getstyles ()
     {
         $result = $this->doRequest();
 


### PR DESCRIPTION
Even if the request type name is checked into controllers, when we used one of the WPS requests object independently, it could be processed with the name of any methods of the object.

Only methods corresponding to the request should be able to be executed. This is why I choose the solution to prefix these methods, so no other methods can be executed.

This naming allows too to identify easily methods of request types.

The issue is related to https://github.com/3liz/lizmap-web-client/pull/2256

