### PR TITLE
Fix: Refused to set unsafe header "Content-Length"

### DIFF
--- a/wps/www/wps.js
+++ b/wps/www/wps.js
@@ -704,8 +704,6 @@ var Petra = function() {
             url: lizUrls['wps_wps'],
             params: lizUrls.params,
             data: data,
-            headers:{
-            },
             success: function(response) {
                 showOutput(theProcess, response, requestTime);
 

--- a/wps/www/wps.js
+++ b/wps/www/wps.js
@@ -705,7 +705,6 @@ var Petra = function() {
             params: lizUrls.params,
             data: data,
             headers:{
-                'Content-Length': data.length
             },
             success: function(response) {
                 showOutput(theProcess, response, requestTime);


### PR DESCRIPTION
XMLHttpRequest isn't allowed to set this header, it is being set automatically by the browser.
The reason is that by manipulating this header you might be able to trick the server into accepting a second request through the same connection,
one that wouldn't go through the usual security checks - that would be a security vulnerability in the browser.

It was an old setting for old browser.

Fixes #17
